### PR TITLE
release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.1.1] — 2026-07-17
+
+### Fixed
+- Clear all 11 open npm audit advisories (5 high): bump `undici` to 7.28.0 (TLS certificate validation bypass via dropped `requestTls` in the SOCKS5 `ProxyAgent`, cross-origin routing through SOCKS5 pool reuse, WebSocket DoS), `form-data` to 4.0.6 (CRLF injection), `vite` to 8.1.5 (`server.fs.deny` bypass and launch-editor NTLMv2 leak), and `js-yaml` to 3.15.0 (quadratic DoS).
+
+### Changed
+- Bump `vue-i18n` to 11.4.5 and `eslint-plugin-vue` to 10.9.2.
+
 ## [1.0.0] — 2026-05-31
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cbragard/lejeudelavie",
-    "version": "1.0.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@cbragard/lejeudelavie",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "license": "MIT",
             "dependencies": {
                 "@babel/preset-env": "7.29.7",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "dist"
     ],
     "type": "module",
-    "version": "1.0.0",
+    "version": "1.1.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com:cbragard/lejeudelavie.git"


### PR DESCRIPTION
Release **patch** — maintenance de dépendances uniquement, **aucun changement de code applicatif**.

Publie le correctif de #17 : les **11 alertes** du dépôt (5 high) fermées — `undici` 7.28.0, `form-data` 4.0.6, `vite` 8.1.5, `js-yaml` 3.15.0, + `vue-i18n` 11.4.5 et `eslint-plugin-vue` 10.9.2. `npm audit` : 0 vulnérabilité.

**Pourquoi une release** : la CI ne construit `ghcr.io/cbragard/lejeudelavie` **que sur un push de tag `v*`**, jamais sur `master` — le merge de #17 n'a donc rien construit.

**`package.json` réaligné 1.0.0 → 1.1.1** : il n'avait **jamais** été bumpé, sur aucune release (il était encore à 1.0.0 au tag `v1.1.0`). `npm version patch` aurait produit 1.0.1 et aggravé la dérive. Impact prod nul (la CI dérive le tag d'image du tag git). Décision utilisateur.

> ℹ️ Le CHANGELOG n'a **aucune entrée `1.1.0`** (la release non-root nginx n'y figure pas) — trou connu, non comblé ici pour garder le commit scopé.
> ℹ️ Mergée en **override admin** : `master` est sous `lock_branch`, verrou conservé volontairement.

Suivi : e-xode/scripts#9