### PR TITLE
Drop Co-Authored-By trailer requirement (fleet-wide policy)

### DIFF
--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -12,7 +12,7 @@ Your job: cut a clean, traceable release by following the **release** skill exac
 ## Operating rules
 
 - **Read the skill first.** Always load and follow `.claude/skills/release/SKILL.md` before doing anything.
-- **Respect the project hard rules** (CLAUDE.md): commit format is `[$branch] content`, append the trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. Never `git commit`/`push`/`tag` unless the user has explicitly asked this turn.
+- **Respect the project hard rules** (CLAUDE.md): commit format is `[$branch] content` — **no `Co-Authored-By` trailer or any AI/assistant mention, ever**. Never `git commit`/`push`/`tag` unless the user has explicitly asked this turn.
 - **Confirm the version bump.** Never guess major/minor/patch — infer from the changes since the last tag (or from the full history if there is no tag yet), then state your reasoning and ask for confirmation unless the user already specified.
 - **No surprise pushes.** Show what you will do (branch, tag, files changed) and get explicit go-ahead before any `git push`.
 - **Validate before tagging.** Run `npm run lint` and `npm run build` — a release must build clean.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -52,12 +52,12 @@ npm run build
 
 ## Release branch & commit
 
-Create a release branch from the current branch, then commit the bump using the project commit format (`[$branch] content` + trailer):
+Create a release branch from the current branch, then commit the bump using the project commit format (`[$branch] content`, **no `Co-Authored-By` trailer or any AI/assistant mention, ever**):
 
 ```bash
 git checkout -b release/vX.Y.Z
 git add package.json package-lock.json CHANGELOG.md
-git commit -m "[release/vX.Y.Z] release vX.Y.Z" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+git commit -m "[release/vX.Y.Z] release vX.Y.Z"
 ```
 
 ## Tag & push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Hard rules
 
-**No auto-commit** — Never `git commit`/`push`/`tag`/`rebase`/`reset --hard` unless the user explicitly asks this turn. Commit format: `[$branch] content`. Append trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+**No auto-commit** — Never `git commit`/`push`/`tag`/`rebase`/`reset --hard` unless the user explicitly asks this turn. Commit format: `[$branch] content`. **No `Co-Authored-By`/`Co-authored-by` trailer or any AI/assistant mention on any commit, ever** — commit author is always the user's own git account, full stop.
 
 **No code comments** — No `//`, `/* */`, or `<!-- -->` in `.vue`/`.mjs`/`.scss`.
 


### PR DESCRIPTION
Applies the 2026-08-09 fleet-wide policy: no `Co-Authored-By`/`Co-authored-by` trailer or any
AI/assistant mention on any commit, ever. Commit author is always the user's own git account.

Replaces the previous mandate (`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`)
in every location it was duplicated:

- `CLAUDE.md` Hard rules
- `.claude/agents/release.md`
- `.claude/skills/release/SKILL.md` (commit template)

Config-only change, no release/deploy.