### PR TITLE
release skill: tag only after merge into master, mandatory PR

### DIFF
--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -23,6 +23,10 @@ Your job: cut a clean, traceable release by following the **release** skill exac
 1. Determine the next version (semver) from commits since the last tag.
 2. Bump `package.json` version (lockfile follows).
 3. Update `CHANGELOG.md` with the new section (create it on the first release).
-4. Commit the bump on a release branch, tag it, and push (after confirmation).
+4. Commit the bump on a release branch and push it (after confirmation).
+5. Open a PR into `master` and merge it — mandatory, this repo requires 1 approving review
+   (`gh pr merge --admin`, self-approval is forbidden).
+6. Only once merged: tag `master` and push the tag. **Never tag the still-unmerged release
+   branch.**
 
 See the skill for exact commands, branch naming, and commit/tag message formats.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -52,26 +52,39 @@ npm run build
 
 ## Release branch & commit
 
-Create a release branch from the current branch, then commit the bump using the project commit format (`[$branch] content`, **no `Co-Authored-By` trailer or any AI/assistant mention, ever**):
+Create a release branch from the current branch, then commit the bump using the project commit format (`[$branch] content`, **no `Co-Authored-By` trailer or any AI/assistant mention, ever**). Only after explicit confirmation (no surprise pushes):
 
 ```bash
 git checkout -b release/vX.Y.Z
 git add package.json package-lock.json CHANGELOG.md
 git commit -m "[release/vX.Y.Z] release vX.Y.Z"
+git push origin release/vX.Y.Z
 ```
 
-## Tag & push
+## Merge into master (mandatory — this repo requires 1 approving review)
 
-Only after explicit confirmation (no surprise pushes):
+`master` is protected (1 approving review, linear history, squash/rebase only) and `lock_branch`ed
+— a PR is not optional here, it's the only way anything lands on `master`:
 
 ```bash
+gh pr create --base master --head release/vX.Y.Z --title "release vX.Y.Z" --body "..."
+gh pr merge --admin --squash --delete-branch   # self-approval forbidden, --admin required
+```
+
+## Tag & push — only once merged
+
+**Tag only after the release branch has merged into `master` — never on the still-unmerged
+release branch, and never optional.** Tagging `v*` triggers the GHCR image build, so the tag must
+point at what actually landed on `master`, not at a commit that could still be rejected in review:
+
+```bash
+git checkout master
+git pull
 git tag -a vX.Y.Z -m "release vX.Y.Z"
-git push origin release/vX.Y.Z
 git push origin vX.Y.Z
 ```
 
 ## Post-release
 
-- Open a PR from `release/vX.Y.Z` into `master` if your flow requires review.
 - Pushing the `vX.Y.Z` tag triggers `.github/workflows/docker-build.yml`, which builds `docker/build/Dockerfile` and publishes to GHCR: `ghcr.io/cbragard/lejeudelavie:latest` and `ghcr.io/cbragard/lejeudelavie:vX.Y.Z`.
 - Verify the image appears in the GHCR packages of the repo.


### PR DESCRIPTION
Config-only doc fix (no release cut, no branch/tag created).

Reorders the release skill (`.claude/skills/release/SKILL.md`) and the release
agent's high-level workflow (`.claude/agents/release.md`) so the sequence is:

1. release branch + commit + push
2. PR into `master`, merge (mandatory — this repo requires 1 approving review,
   `lock_branch`, linear history; `gh pr merge --admin`, self-approval forbidden)
3. tag `master` and push the tag, **only once merged**

Previously the skill tagged and pushed the tag before an optional PR ("Open a
PR ... if your flow requires review"), which could leave a `v*` tag — and the
GHCR build it triggers — pointing at a commit that was never actually merged
as reviewed.

Fleet-wide `claude-config` campaign, hub `e-xode/scripts#18` (~9 of 13 repos
have the same gap).