### PR TITLE
Add automatic plan-escalation hard rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@
 
 **No over-engineering** — This is a one-component toy/benchmark. Keep it simple. YAGNI.
 
+**Plan escalation (automatic)** — heavy analysis/design work in a session below Opus → launch Plan/Explore agents with `model: opus` immediately, announce in one line, never ask (sole exception: user declined escalation, this task or standing); incorporate the returned plan faithfully.
+
 ---
 
 ## Project gotchas


### PR DESCRIPTION
Adds a new hard rule to CLAUDE.md: when a session runs below Opus and the task needs heavy analysis/design work, launch Plan/Explore agents pinned to `model: opus` automatically (announce, don't ask), then incorporate the result and resume on the orchestrator's own model.

Part of fleet-wide claude-config campaign (e-xode/scripts#18). Doc-only change, no runtime impact.