### PR TITLE
add incoming-request-tracking hard rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@
 
 **Plan escalation (automatic)** — heavy analysis/design work in a session below Opus → launch Plan/Explore agents with `model: opus` immediately, announce in one line, never ask (sole exception: user declined escalation, this task or standing); incorporate the returned plan faithfully.
 
+**Every incoming request is tracked** — a new request arriving while another is in progress is never silently dropped or serialised behind it; disjoint file scope → run it in parallel; same file → queue it until the in-progress work finishes.
+
 ---
 
 ## Project gotchas


### PR DESCRIPTION
Fleet-wide claude-config campaign (2026-08-09): adds the "incoming request tracking / write-set-overlap parallelization" hard rule to `CLAUDE.md`.

This repo has no `claude-anthropic` skill (confirmed by prior audit and re-confirmed live: `.claude/skills/{claude-anthropic,skill-creator}` absent), so the rule is added directly as a new concise hard rule in `CLAUDE.md`, matching the treatment already given to the co-author-trailer and Plan-escalation rules in this repo — no `.claude/skills/` infrastructure created.

Ref: e-xode/scripts#18