### PR TITLE
release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.1.2] — 2026-08-11
+
+### Fixed
+- Clear all 30 open Dependabot advisories (16 high / 14 medium): bump the `axios` override from
+  `^1.17.0` to `^1.18.0` (resolves 1.19.0 — prototype pollution, NO_PROXY bypass, form-serializer
+  `maxDepth`/`maxBodyLength` bypasses, deep recursion DoS), `brace-expansion` to 5.0.9/2.1.4/1.1.18
+  (DoS via unbounded intermediate arrays across the three major versions present in the tree),
+  `undici` to 7.29.0 (response desync, cache/cookie information disclosure, CRLF injection),
+  `nanoid` to 3.3.18 (indefinite loop on zero/negative size), `immutable` to 5.1.9 (32-bit trie
+  overflow, hash-collision DoS), `postcss` to 8.5.26 (sourceMappingURL arbitrary file read), and
+  `js-yaml` to 3.15.1 (quadratic CPU consumption in `!!omap` resolution). All transitive; a
+  lockfile refresh (`npm install` + `npm audit fix`, no `--force`) sufficed — every bump stayed on
+  its existing major version. `npm audit`: 0 vulnerabilities. lint + build pass; the repo has no
+  tests, so the built SPA was validated manually (served `dist/`, confirmed the grid renders and
+  the simulation evolves after START).
+
 ## [1.1.1] — 2026-07-17
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cbragard/lejeudelavie",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@cbragard/lejeudelavie",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
                 "@babel/preset-env": "7.29.7",
@@ -4206,13 +4206,13 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+            "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
-                "form-data": "^4.0.5",
+                "form-data": "^4.0.6",
                 "https-proxy-agent": "^5.0.1",
                 "proxy-from-env": "^2.1.0"
             }
@@ -4457,15 +4457,15 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -5073,9 +5073,9 @@
             "license": "MIT"
         },
         "node_modules/editorconfig/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -5850,9 +5850,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -6034,9 +6034,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-            "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "license": "MIT"
         },
         "node_modules/import-local": {
@@ -8046,9 +8046,9 @@
             "license": "MIT"
         },
         "node_modules/js-beautify/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -8103,9 +8103,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -8768,9 +8768,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",
@@ -9102,9 +9102,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.19",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9121,7 +9121,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -9739,9 +9739,9 @@
             "license": "MIT"
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -9936,9 +9936,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "dist"
     ],
     "type": "module",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "repository": {
         "type": "git",
         "url": "git+https://github.com:cbragard/lejeudelavie.git"
@@ -84,6 +84,6 @@
         "vue-i18n": "11.4.5"
     },
     "overrides": {
-        "axios": "^1.17.0"
+        "axios": "^1.18.0"
     }
 }


### PR DESCRIPTION
Clears all 30 open Dependabot advisories (16 high / 14 medium) via a lockfile refresh: axios override bumped ^1.17.0 -> ^1.18.0 (resolves 1.19.0), brace-expansion, undici, nanoid, immutable, postcss, js-yaml all bumped within their existing major versions. No --force, no breaking bumps. `npm audit`: 0 vulnerabilities. lint + build pass; manually validated the built SPA (grid renders, simulation evolves after START) since this repo has no automated tests.

See CHANGELOG.md [1.1.2] for full detail.