### PR TITLE
chore(deps): npm ci in build image, pin npm, add docker ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule: { interval: "weekly" }
+  - package-ecosystem: "docker"
+    directory: "/docker/build"
+    schedule: { interval: "weekly" }

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -10,8 +10,10 @@ ADD . /app
 WORKDIR /app
 
 RUN mkdir /home/node/.npm-global
-RUN npm install -g npm@latest
-RUN npm install --production=false
+RUN npm install -g npm@12.0.2
+# npm ci installs the exact package-lock.json tree; --include=dev is required because NODE_ENV=production
+# would otherwise drop the devDependencies that `npm run build` needs.
+RUN npm ci --include=dev
 RUN npm run build
 
 # ----------------------------------------


### PR DESCRIPTION
Dependency-hygiene cleanup (e-xode/scripts#9):

- `docker/build/Dockerfile`: `npm install` -> `npm ci --include=dev` — same class of non-determinism gap already fixed fleet-wide. Verified with a real local `docker build` (both stages, `--no-cache`) plus a running container serving 200.
- `docker/build/Dockerfile`: pin `npm@latest` -> `npm@12.0.2` (fleet convention, see `vui`/`trading`/`reseau-freelances`).
- `.github/dependabot.yml`: add a `docker` ecosystem entry for `docker/build`.

No release/deploy — hygiene only, ships with the next natural release.