### PR TITLE
align docker runtime on the fleet-standard node:node pattern

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -18,22 +18,31 @@ RUN npm run build
 
 # ----------------------------------------
 
-FROM nginx:1.27-alpine AS runner
+FROM node:24-alpine AS runner
 
 ENV NODE_PORT=3003
 
-COPY --from=builder /app/dist/ /usr/share/nginx/html/
-COPY ./docker/build/config/nginx.conf /etc/nginx/conf.d/default.conf
+RUN apk update
+RUN apk --no-cache add nginx supervisor
 
-# Run the whole container as the built-in non-root `nginx` user (UID/GID 101) instead of root.
-# Static SPA on port 3003 (>1024, no root needed to bind). Move the pid to /tmp, drop the `user`
-# directive (a non-root master can't setuid), and make nginx's writable dirs (cache, conf.d, html)
-# nginx-owned. Access/error logs already go to stdout/stderr (the nginx:alpine image symlinks them),
-# so no log-file or bind-mount ownership change is needed.
-RUN sed -i 's|^user .*|# &|; s|/var/run/nginx.pid|/tmp/nginx.pid|; s|/run/nginx.pid|/tmp/nginx.pid|' /etc/nginx/nginx.conf \
- && chown -R nginx:nginx /var/cache/nginx /var/log/nginx /usr/share/nginx/html /etc/nginx/conf.d
-USER nginx
+EXPOSE $NODE_PORT
 
-EXPOSE 3003
+WORKDIR /app
 
-CMD ["nginx", "-g", "daemon off;"]
+COPY --from=builder /app/dist/ /app/dist/
+COPY ./docker/build/config/nginx.conf /etc/nginx/nginx.conf
+COPY ./docker/build/config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Run the whole container as the built-in non-root `node` user (UID/GID 1000) instead of root —
+# aligned on the fleet-standard pattern (see e-xode/vui). lejeudelavie serves only a static SPA via
+# nginx (no node runtime at request time), but sharing one non-root UID across the fleet means one
+# deploy-script chown pattern everywhere instead of a per-app special case. Own /app + the nginx
+# state/log dirs so the unprivileged nginx (master + worker) can write; supervisord + nginx pidfiles
+# move /run → /tmp. The bind-mounted /app/logs must be 1000:1000 on the host (applied by
+# deploy.e-xode.lejeudelavie.sh) — access/error logs are now real files under /app/logs, not
+# stdout/stderr symlinks.
+RUN mkdir -p /app/logs /var/log/nginx && \
+    chown -R node:node /app /home/node /var/log/nginx /var/lib/nginx
+USER node
+
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/docker/build/config/nginx.conf
+++ b/docker/build/config/nginx.conf
@@ -1,11 +1,52 @@
-server {
-    listen 3003;
-    server_name _;
+worker_processes 1;
+error_log stderr warn;
+pid /tmp/nginx.pid;
 
-    root /usr/share/nginx/html;
-    index index.html;
+events {
+    worker_connections 1024;
+}
 
-    location / {
-        try_files $uri $uri/ /index.html;
+http {
+    include mime.types;
+    default_type application/octet-stream;
+
+    log_format main_timed '$remote_addr - $remote_user [$time_local] "$request" '
+        '$status $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for" '
+        '$request_time $upstream_response_time $pipe $upstream_cache_status';
+
+    access_log /dev/stdout main_timed;
+    error_log /dev/stderr notice;
+
+    keepalive_timeout 65;
+
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp_path;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    server {
+        listen 3003;
+        listen [::]:3003;
+        server_name _;
+        charset utf-8;
+        root /app/dist;
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        error_log /app/logs/lejeudelavie.3003.error.log;
+        access_log /app/logs/lejeudelavie.3003.access.log main_timed;
     }
+
+    gzip on;
+    gzip_proxied any;
+    gzip_types text/plain application/xml text/css text/js text/xml application/x-javascript text/javascript application/json application/xml+rss;
+    gzip_vary on;
+    gzip_disable "msie6";
+
+    include /etc/nginx/conf.d/*.conf;
 }

--- a/docker/build/config/supervisord.conf
+++ b/docker/build/config/supervisord.conf
@@ -1,0 +1,14 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/tmp/supervisord.pid
+
+[program:nginx]
+command=nginx -g 'daemon off;'
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=true
+startretries=5


### PR DESCRIPTION
## Contexte

e-xode/scripts#10 (durcissement des scripts de rollout) notait que `lejeudelavie` monte `logs/` sans jamais faire le `chown`, contrairement aux autres apps — anomalie volontairement non corrigée à l'époque.

Investigation : contrairement à `vui` (process `node`, UID 1000, qui écrit réellement ses logs dans le bind-mount), le conteneur tournait en `nginx:nginx` (UID 101) avec logs redirigés vers stdout/stderr par le Dockerfile — `/app/logs` n'était donc jamais écrit. Un simple `chown -R 1000:1000` aurait été un mauvais UID sans rien apporter.

## Changement

Plutôt que de gérer ce cas particulier, alignement complet sur le pattern fleet-standard (identique à `e-xode/vui`) :

- Image runner `node:24-alpine` (au lieu de `nginx:1.27-alpine`), nginx installé via `apk`, piloté par `supervisord`.
- Tourne sous `node` (UID/GID 1000) au lieu de l'utilisateur `nginx` intégré (UID 101).
- Access/error logs écrits en vrais fichiers dans `/app/logs` (au lieu de symlinks stdout/stderr) — cohérent avec le `chown -R 1000:1000` que le deploy script va appliquer, comme pour toutes les autres apps.
- Comportement SPA (`try_files ... /index.html`) inchangé.

## Vérifié

Build local + run local : conteneur démarre sous `node` (UID 1000), répond HTTP 200, fallback SPA fonctionnel, log d'accès réellement écrit dans `/app/logs` avec la bonne ownership.

**0 test dans ce repo (`testMatch` ne matche rien)** — validation manuelle uniquement, comme documenté dans github.md.