### PR TITLE
release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.1.3] — 2026-08-13
+
+### Changed
+- Docker runtime aligned on the fleet-standard `node:node` pattern (see `e-xode/vui`): runner image
+  switched from `nginx:1.27-alpine` to `node:24-alpine` + `apk add nginx supervisor`, container now
+  runs as `node` (UID/GID 1000) instead of the built-in `nginx` user (UID 101). Access/error logs
+  are now real files under the bind-mounted `/app/logs` instead of stdout/stderr symlinks, so the
+  same `chown -R 1000:1000` deploy-script pattern used by every other app now applies here too —
+  removes the special case flagged in `e-xode/scripts#10`. SPA routing behavior unchanged.
+
 ## [1.1.2] — 2026-08-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cbragard/lejeudelavie",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@cbragard/lejeudelavie",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "license": "MIT",
             "dependencies": {
                 "@babel/preset-env": "7.29.7",

--- a/package.json
+++ b/package.json
@@ -1,89 +1,89 @@
 {
-    "author": "Christophe BRAGARD",
-    "description": "Conway's Game of Life — a Vue 3 rendering benchmark",
-    "homepage": "https://github.com/cbragard/lejeudelavie#readme",
-    "name": "@cbragard/lejeudelavie",
-    "license": "MIT",
-    "files": [
-        "dist"
+  "author": "Christophe BRAGARD",
+  "description": "Conway's Game of Life — a Vue 3 rendering benchmark",
+  "homepage": "https://github.com/cbragard/lejeudelavie#readme",
+  "name": "@cbragard/lejeudelavie",
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "version": "1.1.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com:cbragard/lejeudelavie.git"
+  },
+  "bugs": {
+    "url": "https://github.com/cbragard/lejeudelavie/issues"
+  },
+  "scripts": {
+    "build": "vite --config vite.config.mjs build src",
+    "dev": "vite --host --config vite.config.mjs src",
+    "lint": "eslint src",
+    "preview": "vite --config vite.config.mjs preview src",
+    "test:unit": "jest --clearCache && jest",
+    "test:unit:coverage": "jest --clearCache && jest --coverage",
+    "test:unit:watch": "jest --clearCache && jest --watch"
+  },
+  "babel": {
+    "presets": [
+      [
+        "@babel/preset-env"
+      ]
+    ]
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "mjs",
+      "json",
+      "vue"
     ],
-    "type": "module",
-    "version": "1.1.2",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com:cbragard/lejeudelavie.git"
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1"
     },
-    "bugs": {
-        "url": "https://github.com/cbragard/lejeudelavie/issues"
+    "setupFiles": [],
+    "testEnvironment": "jsdom",
+    "testEnvironmentOptions": {
+      "customExportConditions": [
+        "node",
+        "node-addons"
+      ]
     },
-    "scripts": {
-        "build": "vite --config vite.config.mjs build src",
-        "dev": "vite --host --config vite.config.mjs src",
-        "lint": "eslint src",
-        "preview": "vite --config vite.config.mjs preview src",
-        "test:unit": "jest --clearCache && jest",
-        "test:unit:coverage": "jest --clearCache && jest --coverage",
-        "test:unit:watch": "jest --clearCache && jest --watch"
+    "testMatch": [
+      "**/?(*.)+(spec).mjs"
+    ],
+    "transform": {
+      "^.+\\.m?js$": "babel-jest",
+      "^.+\\.vue$": "@vue/vue3-jest"
     },
-    "babel": {
-        "presets": [
-            [
-                "@babel/preset-env"
-            ]
-        ]
-    },
-    "jest": {
-        "moduleFileExtensions": [
-            "js",
-            "mjs",
-            "json",
-            "vue"
-        ],
-        "moduleNameMapper": {
-            "^@/(.*)$": "<rootDir>/src/$1"
-        },
-        "setupFiles": [],
-        "testEnvironment": "jsdom",
-        "testEnvironmentOptions": {
-            "customExportConditions": [
-                "node",
-                "node-addons"
-            ]
-        },
-        "testMatch": [
-            "**/?(*.)+(spec).mjs"
-        ],
-        "transform": {
-            "^.+\\.m?js$": "babel-jest",
-            "^.+\\.vue$": "@vue/vue3-jest"
-        },
-        "transformIgnorePatterns": [
-            "/node_modules/"
-        ]
-    },
-    "dependencies": {
-        "@babel/preset-env": "7.29.7",
-        "@e-xode/vui": "latest",
-        "@eslint/js": "^10.0.1",
-        "@fortawesome/fontawesome-free": "7.2.0",
-        "@vitejs/plugin-vue": "^6.0.7",
-        "@vue/test-utils": "2.4.10",
-        "@vue/vue3-jest": "29.2.6",
-        "dayjs": "^1.11.21",
-        "eslint": "10.4.1",
-        "eslint-plugin-vue": "10.9.2",
-        "globals": "^17.9.0",
-        "jest": "29.7.0",
-        "jest-environment-jsdom": "29.7.0",
-        "jsdom": "29.1.1",
-        "mitt": "3.0.1",
-        "ramda": "0.32.0",
-        "sass": "1.102.0",
-        "vite": "^8.0.14",
-        "vue": "^3.5.35",
-        "vue-i18n": "11.4.5"
-    },
-    "overrides": {
-        "axios": "^1.18.0"
-    }
+    "transformIgnorePatterns": [
+      "/node_modules/"
+    ]
+  },
+  "dependencies": {
+    "@babel/preset-env": "7.29.7",
+    "@e-xode/vui": "latest",
+    "@eslint/js": "^10.0.1",
+    "@fortawesome/fontawesome-free": "7.2.0",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "@vue/test-utils": "2.4.10",
+    "@vue/vue3-jest": "29.2.6",
+    "dayjs": "^1.11.21",
+    "eslint": "10.4.1",
+    "eslint-plugin-vue": "10.9.2",
+    "globals": "^17.9.0",
+    "jest": "29.7.0",
+    "jest-environment-jsdom": "29.7.0",
+    "jsdom": "29.1.1",
+    "mitt": "3.0.1",
+    "ramda": "0.32.0",
+    "sass": "1.102.0",
+    "vite": "^8.0.14",
+    "vue": "^3.5.35",
+    "vue-i18n": "11.4.5"
+  },
+  "overrides": {
+    "axios": "^1.18.0"
+  }
 }


### PR DESCRIPTION
Version bump + CHANGELOG pour #38 (alignement Docker runtime sur le pattern fleet node:node). lint + build validés.